### PR TITLE
Allow pre-load compiled Typescript modules (ES6/systemjs)

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -1,10 +1,13 @@
 var typescript = Npm.require('typescript');
 
 Plugin.registerSourceHandler('ts', function(compileStep) {
-  var output = typescript.transpile(compileStep.read().toString('utf8'), { module : typescript.ModuleKind.AMD });
+  var output = typescript.transpile(compileStep.read().toString('utf8'), { module : typescript.ModuleKind.System });
+  var moduleName = compileStep.inputPath.replace(/\\/,'/').replace('.ts','');
+  output = output.replace("System.register([",'System.register("'+moduleName+'",[');
 
-  compileStep.addAsset({
+  compileStep.addJavaScript({
     path : compileStep.inputPath.replace('.ts', '.js'),
-    data : output
+    data : output,
+    sourcePath: compileStep.inputPath
   });
 });


### PR DESCRIPTION
Until now, the Modules were loaded dynamically by SystemJS.
In dev mode it is ok, but in production, the Modules are not minified and bundled like the rest of Meteor's app.
With the use of named Modules for System.register, Meteor load the Modules (.js files) normally, and they are used by SystemJS.
To more information look:
[System.register Explained](https://github.com/ModuleLoader/es6-module-loader/wiki/System.register-Explained)

The last version of Typescript 1.5.3-betha is needed.
